### PR TITLE
Fixed #10

### DIFF
--- a/Source/KCVDB.Client/ApiDataSendingEventArgs.cs
+++ b/Source/KCVDB.Client/ApiDataSendingEventArgs.cs
@@ -2,9 +2,9 @@
 
 namespace KCVDB.Client
 {
-	public class ApiDataSendEventArgs : EventArgs
+	public sealed class ApiDataSendingEventArgs : EventArgs
 	{
-		public ApiDataSendEventArgs(
+		public ApiDataSendingEventArgs(
 			Guid trackingId,
 			ApiData apiData)
 		{

--- a/Source/KCVDB.Client/ApiDataSentEventArgs.cs
+++ b/Source/KCVDB.Client/ApiDataSentEventArgs.cs
@@ -1,0 +1,21 @@
+﻿using System;
+
+namespace KCVDB.Client
+{
+	public sealed class ApiDataSentEventArgs : EventArgs
+	{
+		public ApiDataSentEventArgs(
+			Guid trackingId,
+			ApiData apiData,
+			string requestBodyText)
+		{
+			TrackingId = trackingId;
+			ApiData = apiData;
+			RequestBodyText = requestBodyText;
+		}
+
+		public Guid TrackingId { get; }
+		public ApiData ApiData { get; }
+		public string RequestBodyText { get; }
+	}
+}

--- a/Source/KCVDB.Client/Clients/ApiDataSender.cs
+++ b/Source/KCVDB.Client/Clients/ApiDataSender.cs
@@ -32,7 +32,7 @@ namespace KCVDB.Client.Clients
 			HttpClient = new HttpClient();
 		}
 
-		public async Task SendData(ApiData data)
+		public async Task<string> SendData(ApiData data)
 		{
 			if (data == null) { throw new ArgumentNullException(nameof(data)); }
 
@@ -71,6 +71,8 @@ namespace KCVDB.Client.Clients
 						: SendingErrorReason.NetworkError
 					);
 			}
+
+			return contentString;
 		}
 
 		#region IDisposable member

--- a/Source/KCVDB.Client/Clients/IApiDataSender.cs
+++ b/Source/KCVDB.Client/Clients/IApiDataSender.cs
@@ -5,6 +5,6 @@ namespace KCVDB.Client.Clients
 {
 	interface IApiDataSender : IDisposable
 	{
-		Task SendData(ApiData data);
+		Task<string> SendData(ApiData data);
 	}
 }

--- a/Source/KCVDB.Client/Clients/ImmediatelyKCVDBClient.cs
+++ b/Source/KCVDB.Client/Clients/ImmediatelyKCVDBClient.cs
@@ -43,9 +43,9 @@ namespace KCVDB.Client.Clients
 			}
 
 			try {
-				this.ApiDataSending?.Invoke(this, new ApiDataSendEventArgs(actualTrackingId, data));
-				await DataSender.SendData(data);
-				this.ApiDataSent?.Invoke(this, new ApiDataSendEventArgs(actualTrackingId, data));
+				this.ApiDataSending?.Invoke(this, new ApiDataSendingEventArgs(actualTrackingId, data));
+				var contentString = await DataSender.SendData(data);
+				this.ApiDataSent?.Invoke(this, new ApiDataSentEventArgs(actualTrackingId, data, contentString));
 			}
 			catch (DataSendingException ex) {
 				this.SendingError?.Invoke(this, new SendingErrorEventArgs(actualTrackingId, "Failed sending API data.", data, ex));
@@ -60,8 +60,8 @@ namespace KCVDB.Client.Clients
 		}
 
 
-		public event EventHandler<ApiDataSendEventArgs> ApiDataSending;
-		public event EventHandler<ApiDataSendEventArgs> ApiDataSent;
+		public event EventHandler<ApiDataSendingEventArgs> ApiDataSending;
+		public event EventHandler<ApiDataSentEventArgs> ApiDataSent;
 		public event EventHandler<SendingErrorEventArgs> SendingError;
 		public event EventHandler<InternalErrorEventArgs> InternalError;
 		public event EventHandler<FatalErrorEventArgs> FatalError;

--- a/Source/KCVDB.Client/Clients/QueueingKCVDBClient.cs
+++ b/Source/KCVDB.Client/Clients/QueueingKCVDBClient.cs
@@ -146,9 +146,9 @@ namespace KCVDB.Client.Clients
 					var trackingId = item.TrackingId;
 
 					try {
-						this.ApiDataSending?.Invoke(this, new ApiDataSendEventArgs(trackingId, data));
-						await DataSender.SendData(data);
-						this.ApiDataSent?.Invoke(this, new ApiDataSendEventArgs(trackingId, data));
+						this.ApiDataSending?.Invoke(this, new ApiDataSendingEventArgs(trackingId, data));
+						var contentString = await DataSender.SendData(data);
+						this.ApiDataSent?.Invoke(this, new ApiDataSentEventArgs(trackingId, data, contentString));
 
 					}
 					catch (DataSendingException ex) {
@@ -184,8 +184,8 @@ namespace KCVDB.Client.Clients
 			}
 		}
 
-		public event EventHandler<ApiDataSendEventArgs> ApiDataSending;
-		public event EventHandler<ApiDataSendEventArgs> ApiDataSent;
+		public event EventHandler<ApiDataSendingEventArgs> ApiDataSending;
+		public event EventHandler<ApiDataSentEventArgs> ApiDataSent;
 		public event EventHandler<InternalErrorEventArgs> InternalError;
 		public event EventHandler<SendingErrorEventArgs> SendingError;
 		public event EventHandler<FatalErrorEventArgs> FatalError;

--- a/Source/KCVDB.Client/DataMemberAttribute.cs
+++ b/Source/KCVDB.Client/DataMemberAttribute.cs
@@ -1,0 +1,8 @@
+﻿using System;
+
+namespace KCVDB.Client
+{
+	internal class DataMemberAttribute : Attribute
+	{
+	}
+}

--- a/Source/KCVDB.Client/FatalErrorEventArgs.cs
+++ b/Source/KCVDB.Client/FatalErrorEventArgs.cs
@@ -2,7 +2,7 @@
 
 namespace KCVDB.Client
 {
-	public class FatalErrorEventArgs : EventArgs
+	public sealed class FatalErrorEventArgs : EventArgs
 	{
 		public FatalErrorEventArgs(
 			string message,

--- a/Source/KCVDB.Client/IKCVDBClient.cs
+++ b/Source/KCVDB.Client/IKCVDBClient.cs
@@ -21,8 +21,8 @@ namespace KCVDB.Client
 			string dateHeaderValue,
 			Guid? trackingId = null);
 
-		event EventHandler<ApiDataSendEventArgs> ApiDataSending;
-		event EventHandler<ApiDataSendEventArgs> ApiDataSent;
+		event EventHandler<ApiDataSendingEventArgs> ApiDataSending;
+		event EventHandler<ApiDataSentEventArgs> ApiDataSent;
 		event EventHandler<FatalErrorEventArgs> FatalError;
 		event EventHandler<InternalErrorEventArgs> InternalError;
 		event EventHandler<SendingErrorEventArgs> SendingError;

--- a/Source/KCVDB.Client/InternalErrorEventArgs.cs
+++ b/Source/KCVDB.Client/InternalErrorEventArgs.cs
@@ -2,7 +2,7 @@
 
 namespace KCVDB.Client
 {
-	public class InternalErrorEventArgs : EventArgs
+	public sealed class InternalErrorEventArgs : EventArgs
 	{
 		public InternalErrorEventArgs(
 			Guid trackingId,

--- a/Source/KCVDB.Client/KCVDB.Client.csproj
+++ b/Source/KCVDB.Client/KCVDB.Client.csproj
@@ -41,7 +41,8 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="ApiData.cs" />
-    <Compile Include="ApiDataSendEventArgs.cs" />
+    <Compile Include="ApiDataSendingEventArgs.cs" />
+    <Compile Include="ApiDataSentEventArgs.cs" />
     <Compile Include="Clients\ApiDataSender.cs" />
     <Compile Include="Clients\ApiParser.cs" />
     <Compile Include="Clients\HttpSatusCodeExtension.cs" />
@@ -49,6 +50,7 @@
     <Compile Include="Clients\IApiParser.cs" />
     <Compile Include="Clients\ImmediatelyKCVDBClient.cs" />
     <Compile Include="Clients\QueueingKCVDBClient.cs" />
+    <Compile Include="DataMemberAttribute.cs" />
     <Compile Include="Exceptions.cs" />
     <Compile Include="FatalErrorEventArgs.cs" />
     <Compile Include="IKCVDBClient.cs" />

--- a/Source/KCVDB.Client/SendingErrorEventArgs.cs
+++ b/Source/KCVDB.Client/SendingErrorEventArgs.cs
@@ -2,7 +2,7 @@
 
 namespace KCVDB.Client
 {
-	public class SendingErrorEventArgs : EventArgs
+	public sealed class SendingErrorEventArgs : EventArgs
 	{
 		public SendingErrorEventArgs(
 			Guid trackingId,

--- a/Source/KCVDB.TestClient/Program.cs
+++ b/Source/KCVDB.TestClient/Program.cs
@@ -58,6 +58,7 @@ namespace KCVDB.TestClient
 
 			client.ApiDataSent += (_, e) => {
 				Console.WriteLine($"Sending data suceceded ({e.TrackingId})");
+				Console.WriteLine(e.RequestBodyText);
 
 				bool succeeded = false;
 				Guid nextTrackingId;


### PR DESCRIPTION
[Fixes]
 - Separate ApiDataSendEventArgs to *Sending* and *Sent*
 - Add RequestBodyText property to ApIDataSentEventArgs

 Author:    yas-mnkorhym <yasuhiro@aurora.ocn.ne.jp>